### PR TITLE
refactor: remove dead code and duplicated field discovery (#21, #13)

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -19,7 +19,6 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set(TranslationListAdminExtension::class)
         ->args([
-            service('doctrine.orm.entity_manager'),
             param('sonata_translation_list.locales'),
             param('sonata_translation_list.default_locale'),
         ]);

--- a/src/Admin/Extension/TranslationListAdminExtension.php
+++ b/src/Admin/Extension/TranslationListAdminExtension.php
@@ -4,21 +4,15 @@ declare(strict_types=1);
 
 namespace Smartlabs\SonataTranslationListBundle\Admin\Extension;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 
 class TranslationListAdminExtension extends AbstractAdminExtension
 {
-    /** @var array<string, array<string, string>> Cache of discovered fields per model class */
-    private array $fieldCache = [];
-
     /**
      * @param string[] $locales
      */
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
         private readonly array $locales,
         private readonly string $defaultLocale,
     ) {
@@ -54,45 +48,6 @@ class TranslationListAdminExtension extends AbstractAdminExtension
         }
 
         return $parameters;
-    }
-
-    /**
-     * Returns the translatable fields discovered from the Translation entity.
-     *
-     * @return array<string, string> Field name => human-readable label
-     */
-    public function getTranslatableFields(AdminInterface $admin): array
-    {
-        $modelClass = $admin->getModelClass();
-
-        if (isset($this->fieldCache[$modelClass])) {
-            return $this->fieldCache[$modelClass];
-        }
-
-        if (!is_subclass_of($modelClass, TranslatableInterface::class)) {
-            $this->fieldCache[$modelClass] = [];
-            return [];
-        }
-
-        $translationClass = $modelClass::getTranslationEntityClass();
-        $metadata = $this->entityManager->getClassMetadata($translationClass);
-        $fields = [];
-
-        foreach ($metadata->getFieldNames() as $fieldName) {
-            // Skip internal fields
-            if (in_array($fieldName, ['id', 'locale'], true)) {
-                continue;
-            }
-
-            // Convert camelCase to human-readable label
-            $label = ucfirst(trim(preg_replace('/[A-Z]/', ' $0', $fieldName)));
-
-            $fields[$fieldName] = $label;
-        }
-
-        $this->fieldCache[$modelClass] = $fields;
-
-        return $fields;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove unused `getTranslatableFields()` method from `TranslationListAdminExtension`
- Remove `$fieldCache` property and `$entityManager` constructor dependency from Extension
- Remove `service('doctrine.orm.entity_manager')` from Extension service definition
- Field discovery is handled exclusively by `TranslationListRuntime::discoverFields()`

Closes #21
Closes #13

## Test Plan

- [x] `cache:clear` succeeds — container compiles correctly
- [x] Extension service registered with 2 args (locales, defaultLocale) — no doctrine dependency
- [x] Translation list mode works in Sonata Admin (Runtime provides field data)
- [x] No references to removed code remain in the codebase