### PR TITLE
fix: harden SaveTranslationAction security (#20, #10, #9, #23)

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -30,6 +30,7 @@ return static function (ContainerConfigurator $container): void {
             service('sonata.admin.pool'),
             service('doctrine.orm.entity_manager'),
             service('security.csrf.token_manager'),
+            param('sonata_translation_list.locales'),
         ]);
 
     // Twig extension (registers the translation_list_config function)

--- a/src/Action/SaveTranslationAction.php
+++ b/src/Action/SaveTranslationAction.php
@@ -7,6 +7,7 @@ namespace Smartlabs\SonataTranslationListBundle\Action;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\HttpFoundation\Exception\JsonException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,10 +20,14 @@ final class SaveTranslationAction
 
     private const EXCLUDED_FIELDS = ['id', 'locale'];
 
+    /**
+     * @param string[] $locales
+     */
     public function __construct(
         private readonly Pool $adminPool,
         private readonly EntityManagerInterface $entityManager,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly array $locales,
     ) {
     }
 
@@ -38,7 +43,12 @@ final class SaveTranslationAction
             return new JsonResponse(['status' => 'error', 'message' => 'Invalid CSRF token'], Response::HTTP_FORBIDDEN);
         }
 
-        $data = json_decode($request->getContent(), true);
+        // JSON body validation (#20)
+        try {
+            $data = $request->toArray();
+        } catch (JsonException) {
+            return new JsonResponse(['status' => 'error', 'message' => 'Invalid JSON body'], Response::HTTP_BAD_REQUEST);
+        }
 
         $adminCode = $data['adminCode'] ?? null;
         $objectId = $data['objectId'] ?? null;
@@ -50,21 +60,26 @@ final class SaveTranslationAction
             return new JsonResponse(['status' => 'error', 'message' => 'Missing required parameters'], Response::HTTP_BAD_REQUEST);
         }
 
+        // Locale validation (#23)
+        if (!in_array($locale, $this->locales, true)) {
+            return new JsonResponse(['status' => 'error', 'message' => sprintf('Invalid locale "%s"', $locale)], Response::HTTP_BAD_REQUEST);
+        }
+
         try {
             $admin = $this->adminPool->getAdminByAdminCode($adminCode);
         } catch (\InvalidArgumentException) {
             return new JsonResponse(['status' => 'error', 'message' => 'Invalid admin code'], Response::HTTP_BAD_REQUEST);
         }
 
-        // Permission check
-        if (!$admin->hasAccess('edit')) {
-            return new JsonResponse(['status' => 'error', 'message' => 'Access denied'], Response::HTTP_FORBIDDEN);
-        }
-
         $object = $admin->getObject($objectId);
 
         if (null === $object) {
             return new JsonResponse(['status' => 'error', 'message' => 'Object not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        // Object-level permission check (#9)
+        if (!$admin->hasAccess('edit', $object)) {
+            return new JsonResponse(['status' => 'error', 'message' => 'Access denied'], Response::HTTP_FORBIDDEN);
         }
 
         if (!$object instanceof TranslatableInterface) {
@@ -78,6 +93,28 @@ final class SaveTranslationAction
 
         if (!in_array($field, $allowedFields, true)) {
             return new JsonResponse(['status' => 'error', 'message' => 'Invalid field name'], Response::HTTP_BAD_REQUEST);
+        }
+
+        // Type-aware value coercion (#10)
+        $fieldMapping = $metadata->getFieldMapping($field);
+        $expectedType = $fieldMapping->type ?? 'string';
+
+        if ($value === '' && !in_array($expectedType, ['string', 'text'], true)) {
+            $value = null;
+        } else {
+            $value = match ($expectedType) {
+                'boolean' => filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+                'integer', 'smallint', 'bigint' => filter_var($value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE),
+                'float', 'decimal' => filter_var($value, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE),
+                default => $value,
+            };
+
+            if (null === $value && !in_array($expectedType, ['string', 'text'], true)) {
+                return new JsonResponse(
+                    ['status' => 'error', 'message' => sprintf('Invalid value for field "%s" (expected %s)', $field, $expectedType)],
+                    Response::HTTP_BAD_REQUEST
+                );
+            }
         }
 
         // Set translation value


### PR DESCRIPTION
## Summary

- **#20**: Replace `json_decode()` with `$request->toArray()` + catch `JsonException` for proper error handling
- **#10**: Add type-aware value coercion via `filter_var()` for boolean, integer, and float fields based on Doctrine field metadata
- **#9**: Move permission check after object load to enable object-level authorization: `hasAccess('edit', $object)`
- **#23**: Inject configured locales and validate submitted locale against them before any database operation

### Security hardening order in the action:
1. POST method → 2. CSRF token → 3. JSON body validation → 4. Required params → 5. Locale validation → 6. Admin code → 7. Object load → 8. Object-level permission → 9. TranslatableInterface → 10. Field validation → 11. Type coercion → 12. Save

Closes #20
Closes #10
Closes #9
Closes #23

## Test Plan

- [x] `cache:clear` succeeds — container compiles correctly
- [x] SaveTranslationAction service has 4 args (pool, entityManager, csrfTokenManager, locales)
- [x] Normal inline editing works in translation list mode
- [x] Boolean fields save as true/false (not string "1"/"0")
- [x] Invalid JSON body returns HTTP 400
- [x] Unconfigured locale returns HTTP 400
- [x] Permission check uses object-level authorization