### PR TITLE
fix: route prefix, configurable CKEditor paths, CSRF prompt (#12, #15, #16)

### DIFF
--- a/config/routing.php
+++ b/config/routing.php
@@ -6,7 +6,7 @@ use Smartlabs\SonataTranslationListBundle\Action\SaveTranslationAction;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 return static function (RoutingConfigurator $routes): void {
-    $routes->add('sonata_translation_list_save', '/admin/translation-list/save')
+    $routes->add('sonata_translation_list_save', '/translation-list/save')
         ->controller(SaveTranslationAction::class)
         ->methods(['POST']);
 };

--- a/config/services.php
+++ b/config/services.php
@@ -44,5 +44,6 @@ return static function (ContainerConfigurator $container): void {
             service('doctrine.orm.entity_manager'),
             param('sonata_translation_list.locales'),
             param('sonata_translation_list.default_locale'),
+            param('sonata_translation_list.ckeditor_paths'),
         ]);
 };

--- a/public/js/translation-list.js
+++ b/public/js/translation-list.js
@@ -24,11 +24,22 @@
         var saveUrl = saveUrlEl.getAttribute('data-url');
         var csrfToken = csrfTokenEl.getAttribute('data-token');
 
+        // Read optional CKEditor paths from config element
+        var ckeditorConfigEl = document.getElementById('translation-list-ckeditor-config');
+        var ckeditorPaths = null;
+        if (ckeditorConfigEl) {
+            try {
+                ckeditorPaths = JSON.parse(ckeditorConfigEl.getAttribute('data-paths'));
+            } catch (e) {
+                ckeditorPaths = null;
+            }
+        }
+
         hideOriginalElements();
         createStickyHeaders();
         initFieldToggles();
         initInputs(saveUrl, csrfToken);
-        preloadCKEditor();
+        preloadCKEditor(ckeditorPaths);
     }
 
     // --- CKEditor lazy loading ---
@@ -37,7 +48,7 @@
      * Preload the CKEditor script in the background (non-blocking).
      * Does NOT create any editor instances yet.
      */
-    function preloadCKEditor() {
+    function preloadCKEditor(configuredPaths) {
         if (typeof CKEDITOR !== 'undefined') {
             ckeditorLoaded = true;
             return;
@@ -49,7 +60,9 @@
         }
 
         ckeditorLoading = true;
-        var paths = ['/ckeditor/ckeditor.js', '/bundles/fosckeditor/ckeditor.js'];
+        var paths = (configuredPaths && configuredPaths.length)
+            ? configuredPaths
+            : ['/ckeditor/ckeditor.js', '/bundles/fosckeditor/ckeditor.js'];
         tryLoadScript(paths, 0, function () {
             ckeditorLoaded = true;
             ckeditorLoading = false;
@@ -422,6 +435,12 @@
                     container.classList.remove('translation-saved');
                 }, 2000);
             } else {
+                if (result.data.message === 'Invalid CSRF token') {
+                    if (confirm('Your session has expired. Please reload the page to continue editing.')) {
+                        window.location.reload();
+                        return;
+                    }
+                }
                 container.classList.add('translation-error');
                 container.title = result.data.message || 'Save failed';
             }

--- a/src/SonataTranslationListBundle.php
+++ b/src/SonataTranslationListBundle.php
@@ -25,6 +25,11 @@ class SonataTranslationListBundle extends AbstractBundle
                     ->defaultValue('%kernel.default_locale%')
                     ->info('The default (source) locale.')
                 ->end()
+                ->arrayNode('ckeditor_paths')
+                    ->defaultValue([])
+                    ->scalarPrototype()->end()
+                    ->info('Custom CKEditor script paths. If empty, default paths are used.')
+                ->end()
             ->end()
         ;
     }
@@ -33,6 +38,7 @@ class SonataTranslationListBundle extends AbstractBundle
     {
         $builder->setParameter('sonata_translation_list.locales', $config['locales']);
         $builder->setParameter('sonata_translation_list.default_locale', $config['default_locale']);
+        $builder->setParameter('sonata_translation_list.ckeditor_paths', $config['ckeditor_paths']);
 
         $container->import('../config/services.php');
     }

--- a/src/Twig/TranslationListRuntime.php
+++ b/src/Twig/TranslationListRuntime.php
@@ -16,11 +16,13 @@ class TranslationListRuntime implements RuntimeExtensionInterface
 
     /**
      * @param string[] $locales
+     * @param string[] $ckeditorPaths
      */
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly array $locales,
         private readonly string $defaultLocale,
+        private readonly array $ckeditorPaths = [],
     ) {
     }
 
@@ -37,6 +39,7 @@ class TranslationListRuntime implements RuntimeExtensionInterface
             'fields' => $this->discoverFields($modelClass),
             'locales' => $this->locales,
             'defaultLocale' => $this->defaultLocale,
+            'ckeditorPaths' => $this->ckeditorPaths,
         ];
     }
 

--- a/templates/list_outer_rows_translation.html.twig
+++ b/templates/list_outer_rows_translation.html.twig
@@ -155,6 +155,9 @@
             <span id="translation-list-save-url" data-url="{{ path('sonata_translation_list_save') }}"></span>
             <span id="translation-list-csrf-token" data-token="{{ csrf_token }}"></span>
             <span id="translation-list-active-fields" data-fields="{{ active_fields|join(',') }}"></span>
+            {% if config.ckeditorPaths is not empty %}
+                <span id="translation-list-ckeditor-config" data-paths="{{ config.ckeditorPaths|json_encode|e('html_attr') }}"></span>
+            {% endif %}
         </td>
     </tr>
 {% endif %}


### PR DESCRIPTION
## Summary

- **#12**: Remove hardcoded `/admin` prefix from route path — apps provide prefix via `->prefix()` on import
- **#15**: Add `ckeditor_paths` config option (default `[]`). JS reads custom paths from DOM via `JSON.parse`, falls back to default paths (`/ckeditor/ckeditor.js`, `/bundles/fosckeditor/ckeditor.js`)
- **#16**: Show `confirm()` reload dialog when CSRF token expires (HTTP 403 with "Invalid CSRF token"). Non-CSRF 403 errors still show standard error indicator

**Note:** Demo app route import updated to `->prefix('/admin')` (committed separately in demo repo).

Closes #12
Closes #15
Closes #16

## Test Plan

- [x] `cache:clear` succeeds
- [x] Route resolves to `/admin/translation-list/save` (prefix from demo app import)
- [x] `debug:config` shows `ckeditor_paths: {}` (empty = JS uses defaults)
- [x] `assets:install public` copies updated JS
- [x] Translation list inline editing works
- [x] CKEditor loads with default paths (no config override)