### PR TITLE
chore: composer v1.0.0 metadata and stability (#25)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
     "homepage": "https://github.com/smartlabsAT/sonata-translation-list-bundle",
     "version": "1.0.0",
     "license": "MIT",
+    "support": {
+        "issues": "https://github.com/smartlabsAT/sonata-translation-list-bundle/issues",
+        "source": "https://github.com/smartlabsAT/sonata-translation-list-bundle"
+    },
     "authors": [
         {
             "name": "Christopher Schwarz",
@@ -34,6 +38,8 @@
             "Smartlabs\\SonataTranslationListBundle\\Tests\\": "tests/"
         }
     },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-main": "1.0.x-dev"


### PR DESCRIPTION
## Summary

- Add `support.issues` and `support.source` URLs for Packagist/GitHub integration
- Add `minimum-stability: stable` and `prefer-stable: true`
- All existing fields (keywords, homepage, authors, version, dependencies) verified correct

Closes #25

## Test Plan

- [x] `composer validate` passes (warning about version field is expected/intentional)