### PR TITLE
test: unit tests and CI pipeline (#8, #24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.2', '8.3']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - run: composer install --no-progress --prefer-dist
+
+      - run: vendor/bin/phpunit --no-coverage

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    failOnRisky="true"
+    failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="SmartlabsSonataTranslationList Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/Action/SaveTranslationActionTest.php
+++ b/tests/Action/SaveTranslationActionTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smartlabs\SonataTranslationListBundle\Tests\Action;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Smartlabs\SonataTranslationListBundle\Action\SaveTranslationAction;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class SaveTranslationActionTest extends TestCase
+{
+    private ContainerInterface&MockObject $container;
+    private EntityManagerInterface&MockObject $entityManager;
+    private CsrfTokenManagerInterface&MockObject $csrfTokenManager;
+
+    protected function setUp(): void
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+    }
+
+    private function createAction(array $adminServiceCodes = [], array $locales = ['de', 'en']): SaveTranslationAction
+    {
+        $pool = new Pool($this->container, $adminServiceCodes);
+
+        return new SaveTranslationAction(
+            $pool,
+            $this->entityManager,
+            $this->csrfTokenManager,
+            $locales,
+        );
+    }
+
+    private function createJsonRequest(array $data, string $method = 'POST', string $csrfToken = 'valid-token'): Request
+    {
+        $request = Request::create('/save', $method, [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode($data, JSON_THROW_ON_ERROR));
+
+        $request->headers->set('X-CSRF-Token', $csrfToken);
+
+        return $request;
+    }
+
+    private function setupValidCsrf(): void
+    {
+        $this->csrfTokenManager->method('isTokenValid')->willReturn(true);
+    }
+
+    private function setupInvalidCsrf(): void
+    {
+        $this->csrfTokenManager->method('isTokenValid')->willReturn(false);
+    }
+
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'adminCode' => 'test_admin',
+            'objectId' => '1',
+            'locale' => 'en',
+            'field' => 'title',
+            'value' => 'Test Value',
+        ], $overrides);
+    }
+
+    // --- Tests ---
+
+    public function testMethodNotAllowed(): void
+    {
+        $action = $this->createAction();
+        $request = Request::create('/save', 'GET');
+
+        $response = $action($request);
+
+        self::assertSame(405, $response->getStatusCode());
+    }
+
+    public function testInvalidCsrfToken(): void
+    {
+        $this->setupInvalidCsrf();
+        $action = $this->createAction();
+
+        $response = $action($this->createJsonRequest($this->validPayload()));
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('CSRF', json_decode($response->getContent(), true)['message']);
+    }
+
+    public function testInvalidJsonBody(): void
+    {
+        $this->setupValidCsrf();
+        $action = $this->createAction();
+
+        $request = Request::create('/save', 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '{broken json');
+        $request->headers->set('X-CSRF-Token', 'valid-token');
+
+        $response = $action($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('Invalid JSON', json_decode($response->getContent(), true)['message']);
+    }
+
+    public function testMissingParameters(): void
+    {
+        $this->setupValidCsrf();
+        $action = $this->createAction();
+
+        $response = $action($this->createJsonRequest(['adminCode' => 'test']));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('Missing', json_decode($response->getContent(), true)['message']);
+    }
+
+    public function testInvalidLocale(): void
+    {
+        $this->setupValidCsrf();
+        $action = $this->createAction();
+
+        $response = $action($this->createJsonRequest($this->validPayload(['locale' => 'xx'])));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('Invalid locale', json_decode($response->getContent(), true)['message']);
+    }
+
+    public function testInvalidAdminCode(): void
+    {
+        $this->setupValidCsrf();
+        // No admin registered → getAdminByAdminCode throws
+        $action = $this->createAction();
+
+        $response = $action($this->createJsonRequest($this->validPayload()));
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    public function testObjectNotFound(): void
+    {
+        $this->setupValidCsrf();
+
+        $admin = $this->createMock(AdminInterface::class);
+        $admin->method('getObject')->willReturn(null);
+        $this->container->method('get')->with('test_admin')->willReturn($admin);
+
+        $action = $this->createAction(['test_admin']);
+
+        $response = $action($this->createJsonRequest($this->validPayload()));
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testAccessDenied(): void
+    {
+        $this->setupValidCsrf();
+
+        $object = $this->createMock(TranslatableInterface::class);
+
+        $admin = $this->createMock(AdminInterface::class);
+        $admin->method('getObject')->willReturn($object);
+        $admin->method('hasAccess')->with('edit', $object)->willReturn(false);
+        $this->container->method('get')->with('test_admin')->willReturn($admin);
+
+        $action = $this->createAction(['test_admin']);
+
+        $response = $action($this->createJsonRequest($this->validPayload()));
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('Access denied', json_decode($response->getContent(), true)['message']);
+    }
+
+    public function testNonTranslatableEntity(): void
+    {
+        $this->setupValidCsrf();
+
+        $object = new \stdClass();
+
+        $admin = $this->createMock(AdminInterface::class);
+        $admin->method('getObject')->willReturn($object);
+        $admin->method('hasAccess')->willReturn(true);
+        $this->container->method('get')->with('test_admin')->willReturn($admin);
+
+        $action = $this->createAction(['test_admin']);
+
+        $response = $action($this->createJsonRequest($this->validPayload()));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('not translatable', json_decode($response->getContent(), true)['message']);
+    }
+}

--- a/tests/Admin/Extension/TranslationListAdminExtensionTest.php
+++ b/tests/Admin/Extension/TranslationListAdminExtensionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smartlabs\SonataTranslationListBundle\Tests\Admin\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Smartlabs\SonataTranslationListBundle\Admin\Extension\TranslationListAdminExtension;
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+class TranslationListAdminExtensionTest extends TestCase
+{
+    private TranslationListAdminExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new TranslationListAdminExtension(
+            ['de', 'en', 'fr'],
+            'de',
+        );
+    }
+
+    public function testConfigure(): void
+    {
+        $admin = $this->createMock(AdminInterface::class);
+
+        $admin->method('getListModes')->willReturn([
+            'list' => ['class' => 'fas fa-list fa-fw'],
+        ]);
+
+        $admin->expects(self::once())
+            ->method('setListModes')
+            ->with(self::callback(function (array $modes): bool {
+                return isset($modes['translation'])
+                    && str_contains($modes['translation']['icon'], 'fa-language');
+            }));
+
+        $admin->expects(self::once())
+            ->method('setTemplate')
+            ->with('outer_list_rows_translation', '@SonataTranslationList/list_outer_rows_translation.html.twig');
+
+        $this->extension->configure($admin);
+    }
+
+    public function testConfigurePersistentParametersWithTranslationFields(): void
+    {
+        $admin = $this->createMock(AdminInterface::class);
+        $request = new \Symfony\Component\HttpFoundation\Request(['translation_fields' => 'title,description']);
+
+        $admin->method('hasRequest')->willReturn(true);
+        $admin->method('getRequest')->willReturn($request);
+
+        $result = $this->extension->configurePersistentParameters($admin, []);
+
+        self::assertSame('title,description', $result['translation_fields']);
+    }
+
+    public function testConfigurePersistentParametersWithLegacyParam(): void
+    {
+        $admin = $this->createMock(AdminInterface::class);
+        $request = new \Symfony\Component\HttpFoundation\Request(['translation_field' => 'title']);
+
+        $admin->method('hasRequest')->willReturn(true);
+        $admin->method('getRequest')->willReturn($request);
+
+        $result = $this->extension->configurePersistentParameters($admin, []);
+
+        self::assertSame('title', $result['translation_fields']);
+    }
+
+    public function testConfigurePersistentParametersWithoutRequest(): void
+    {
+        $admin = $this->createMock(AdminInterface::class);
+        $admin->method('hasRequest')->willReturn(false);
+
+        $result = $this->extension->configurePersistentParameters($admin, ['existing' => 'value']);
+
+        self::assertSame(['existing' => 'value'], $result);
+    }
+
+    public function testGetLocales(): void
+    {
+        self::assertSame(['de', 'en', 'fr'], $this->extension->getLocales());
+    }
+
+    public function testGetDefaultLocale(): void
+    {
+        self::assertSame('de', $this->extension->getDefaultLocale());
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smartlabs\SonataTranslationListBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Smartlabs\SonataTranslationListBundle\SonataTranslationListBundle;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
+
+class ConfigurationTest extends TestCase
+{
+    private function processConfig(array $config): array
+    {
+        $bundle = new SonataTranslationListBundle();
+
+        $treeBuilder = new TreeBuilder('sonata_translation_list');
+        $loader = new DefinitionFileLoader($treeBuilder, new FileLocator());
+        $definition = new DefinitionConfigurator($treeBuilder, $loader, __DIR__, __FILE__);
+
+        $bundle->configure($definition);
+
+        $tree = $treeBuilder->buildTree();
+
+        return (new Processor())->process($tree, [$config]);
+    }
+
+    public function testDefaultConfiguration(): void
+    {
+        $config = $this->processConfig(['locales' => ['en']]);
+
+        self::assertSame('%kernel.default_locale%', $config['default_locale']);
+        self::assertSame([], $config['ckeditor_paths']);
+    }
+
+    public function testLocalesRequired(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig([]);
+    }
+
+    public function testLocalesRequiresAtLeastOneElement(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig(['locales' => []]);
+    }
+
+    public function testCustomConfiguration(): void
+    {
+        $config = $this->processConfig([
+            'locales' => ['en', 'fr', 'es'],
+            'default_locale' => 'en',
+        ]);
+
+        self::assertSame(['en', 'fr', 'es'], $config['locales']);
+        self::assertSame('en', $config['default_locale']);
+    }
+
+    public function testCkeditorPathsDefault(): void
+    {
+        $config = $this->processConfig(['locales' => ['en']]);
+
+        self::assertSame([], $config['ckeditor_paths']);
+    }
+
+    public function testCkeditorPathsCustom(): void
+    {
+        $config = $this->processConfig([
+            'locales' => ['en'],
+            'ckeditor_paths' => ['/build/ckeditor/ckeditor.js'],
+        ]);
+
+        self::assertSame(['/build/ckeditor/ckeditor.js'], $config['ckeditor_paths']);
+    }
+}

--- a/tests/SmartlabsSonataTranslationListBundleTest.php
+++ b/tests/SmartlabsSonataTranslationListBundleTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smartlabs\SonataTranslationListBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Smartlabs\SonataTranslationListBundle\SonataTranslationListBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class SmartlabsSonataTranslationListBundleTest extends TestCase
+{
+    private function createContainerBuilder(): ContainerBuilder
+    {
+        return new ContainerBuilder(new ParameterBag([
+            'kernel.environment' => 'test',
+            'kernel.build_dir' => sys_get_temp_dir(),
+            'kernel.debug' => true,
+        ]));
+    }
+
+    public function testLoadExtensionRegistersServices(): void
+    {
+        $bundle = new SonataTranslationListBundle();
+        $container = $this->createContainerBuilder();
+
+        $extension = $bundle->getContainerExtension();
+        $extension->load([['locales' => ['en', 'de'], 'default_locale' => 'en', 'ckeditor_paths' => []]], $container);
+
+        self::assertTrue($container->hasParameter('sonata_translation_list.locales'));
+        self::assertSame(['en', 'de'], $container->getParameter('sonata_translation_list.locales'));
+        self::assertSame('en', $container->getParameter('sonata_translation_list.default_locale'));
+        self::assertSame([], $container->getParameter('sonata_translation_list.ckeditor_paths'));
+    }
+
+    public function testPrependExtensionRegistersSonataAdminAssets(): void
+    {
+        $bundle = new SonataTranslationListBundle();
+        $container = $this->createContainerBuilder();
+
+        $sonataAdminExtension = $this->createMock(ExtensionInterface::class);
+        $sonataAdminExtension->method('getAlias')->willReturn('sonata_admin');
+        $container->registerExtension($sonataAdminExtension);
+
+        $extension = $bundle->getContainerExtension();
+        $extension->prepend($container);
+
+        $configs = $container->getExtensionConfig('sonata_admin');
+
+        self::assertNotEmpty($configs);
+        self::assertArrayHasKey('assets', $configs[0]);
+        self::assertContains(
+            'bundles/sonatatranslationlist/js/translation-list.js',
+            $configs[0]['assets']['extra_javascripts']
+        );
+        self::assertContains(
+            'bundles/sonatatranslationlist/css/translation-list.css',
+            $configs[0]['assets']['extra_stylesheets']
+        );
+    }
+
+    public function testPrependExtensionSkipsWhenSonataAdminAbsent(): void
+    {
+        $bundle = new SonataTranslationListBundle();
+        $container = $this->createContainerBuilder();
+
+        $extension = $bundle->getContainerExtension();
+        $extension->prepend($container);
+
+        self::assertEmpty($container->getExtensionConfig('sonata_admin'));
+    }
+}


### PR DESCRIPTION
## Summary

- **#8**: 24 unit tests across 4 test classes:
  - `TranslationListAdminExtensionTest` (6 tests) — configure, persistent params, locale accessors
  - `SaveTranslationActionTest` (9 tests) — method check, CSRF, JSON, params, locale, admin, object, access, translatable
  - `ConfigurationTest` (6 tests) — defaults, required locales, custom config, ckeditor paths
  - `SmartlabsSonataTranslationListBundleTest` (3 tests) — service registration, prepend with/without sonata_admin
- **#24**: GitHub Actions CI pipeline with PHP 8.2 + 8.3 matrix, triggered on PRs to main
- `phpunit.xml.dist` with `bootstrap="vendor/autoload.php"` for CI

Closes #8
Closes #24

## Test Plan

- [x] All 24 tests pass locally (PHPUnit 12.5.14, PHP 8.3.30)
- [x] 46 assertions, 0 errors, 0 failures
- [x] Pure unit tests with mocks — no database dependency
- [x] `phpunit.xml.dist` configured for CI bootstrap